### PR TITLE
[PR] Fix for Type Inference Bug during String Comparison Check

### DIFF
--- a/src/main/java/ca/uwaterloo/ece/feedet/bugpatterns/IncorrectStringCompare.java
+++ b/src/main/java/ca/uwaterloo/ece/feedet/bugpatterns/IncorrectStringCompare.java
@@ -31,8 +31,8 @@ public class IncorrectStringCompare extends Bug {
 			
 			
 			if((infixExp.getOperator() == Operator.NOT_EQUALS || infixExp.getOperator() == Operator.EQUALS)) {
-				if ((wholeCodeAST.getTypeOfSimpleName(infixExp, infixExp.getLeftOperand().toString()).equals("String")&&!isNull(infixExp.getRightOperand()))
-						||(wholeCodeAST.getTypeOfSimpleName(infixExp, infixExp.getRightOperand().toString()).equals("String")&&!isNull(infixExp.getLeftOperand()))) {
+				if ((wholeCodeAST.getTypeOfSimpleName(infixExp, infixExp.getLeftOperand()).equals("String")&&!isNull(infixExp.getRightOperand()))
+						||(wholeCodeAST.getTypeOfSimpleName(infixExp, infixExp.getRightOperand()).equals("String")&&!isNull(infixExp.getLeftOperand()))) {
 						
 					int lineNum = wholeCodeAST.getLineNum(infixExp.getStartPosition());
 				

--- a/src/main/java/ca/uwaterloo/ece/feedet/bugpatterns/IntOverflowOfMathMin.java
+++ b/src/main/java/ca/uwaterloo/ece/feedet/bugpatterns/IntOverflowOfMathMin.java
@@ -93,9 +93,9 @@ public class IntOverflowOfMathMin extends Bug {
 	}
 
 	private boolean haveIntegerMaxLengthCheck(MethodInvocation methodInv, Expression expCasted) {
-		
-		ArrayList<String> simpleNames = getSimpleNames(expCasted);
-		
+
+		ArrayList<Expression> simpleNames = getSimpleNames(expCasted);
+
 		ASTNode node = methodInv.getParent();
 		while(node!=null){
 			if(!(node instanceof IfStatement)){
@@ -116,10 +116,10 @@ public class IntOverflowOfMathMin extends Bug {
 			
 			for(InfixExpression infixExp:infixExps){
 				if((infixExp.getRightOperand().toString().contains("Integer.MAX_VALUE")
-						&& simpleNames.contains(infixExp.getLeftOperand().toString()))
+						&& simpleNames.contains(infixExp.getLeftOperand()))
 						||
 					(infixExp.getLeftOperand().toString().contains("Integer.MAX_VALUE")
-						&& simpleNames.contains(infixExp.getRightOperand().toString())))
+						&& simpleNames.contains(infixExp.getRightOperand())))
 					return true;
 			}
 			node = node.getParent();
@@ -131,10 +131,10 @@ public class IntOverflowOfMathMin extends Bug {
 	private boolean containsLongVariable(Expression expression) {
 		
 		if(expression instanceof MethodInvocation) return false; // only consider expression contains only long variables, otherwise ignore.
-		
-		ArrayList<String> simpleNames = getSimpleNames(expression);
-		
-		for(String simpleName:simpleNames){
+
+		ArrayList<Expression> simpleNames = getSimpleNames(expression);
+
+		for(Expression simpleName:simpleNames){
 			if(wholeCodeAST.getTypeOfSimpleName(expression, simpleName).equals("long"))
 				return true;
 		}
@@ -142,17 +142,17 @@ public class IntOverflowOfMathMin extends Bug {
 		return false;
 	}
 
-	private ArrayList<String> getSimpleNames(Expression expression) {
-		final ArrayList<String> simpleNames = new ArrayList<String>();
+	private ArrayList<Expression> getSimpleNames(Expression expression) {
+		final ArrayList<Expression> simpleNames = new ArrayList<>();
 		if(expression instanceof SimpleName){
-			simpleNames.add(expression.toString());
+			simpleNames.add(expression);
 			return simpleNames;
 		}
 		
 		expression.accept(new ASTVisitor() {
 			@Override
 			public boolean visit(SimpleName node) {
-				simpleNames.add(node.toString());
+				simpleNames.add(node);
 				return super.visit(node);
 			}
 		}

--- a/src/main/java/ca/uwaterloo/ece/feedet/utils/JavaASTParser.java
+++ b/src/main/java/ca/uwaterloo/ece/feedet/utils/JavaASTParser.java
@@ -738,22 +738,21 @@ public class JavaASTParser {
 			return "";
 		
 		if(node instanceof SimpleName)
-			return getTypeOfSimpleName(node,node.toString());
-		
+			return getTypeOfSimpleName(node, node);
+
 		if(node instanceof ArrayAccess){
-			return getTypeOfSimpleName(node,getOnlyNameFromArrayAccess(node));
+			return getTypeOfSimpleName(node, node);
 		}
 		
 		// receiver.fieldName
 		if(node instanceof QualifiedName){
 			
 			QualifiedName qName = (QualifiedName) node;
-			
-			String receiverName = qName.getQualifier().toString();
+
 			String fieldName = qName.getName().toString();
-			
-			String typeNameOfReceiver = getTypeOfSimpleName(node,receiverName);
-			
+
+			String typeNameOfReceiver = getTypeOfSimpleName(node, qName.getQualifier());
+
 			String typeNameIfReceiverIsInInnerClass = qulifiedNameInInnerClass(typeNameOfReceiver,fieldName);
 			if(!typeNameIfReceiverIsInInnerClass.isEmpty()) return typeNameIfReceiverIsInInnerClass;
 			
@@ -927,9 +926,9 @@ public class JavaASTParser {
 		
 		return operand.toString();
 	}
-	
-	public String getTypeOfSimpleName(ASTNode astNode,String name) {
-		
+
+	public String getTypeOfSimpleName(ASTNode astNode, Expression operand) {
+
 		// TODO need to find a target name in a hierarchy but not globally in a file
 		final ArrayList<SingleVariableDeclaration> lstSingleVarDecs = new ArrayList<SingleVariableDeclaration>();
 		final ArrayList<VariableDeclarationStatement> lstVarDecStmts = new ArrayList<VariableDeclarationStatement>();
@@ -957,13 +956,14 @@ public class JavaASTParser {
 		);
 		
 		for(SingleVariableDeclaration dec:lstSingleVarDecs){
-			if (dec.getName().toString().equals(name))
+			if (dec.getName().toString().equals(operand.toString())
+				&& dec.getParent().equals(getMethodDec(operand)))
 				return dec.getType().toString();
 		}
 		for(VariableDeclarationStatement dec:lstVarDecStmts){
 			for(Object node:dec.fragments()){
 				if(node instanceof VariableDeclarationFragment){
-					if (((VariableDeclarationFragment)node).getName().toString().equals(name))
+					if (((VariableDeclarationFragment)node).getName().toString().equals(operand.toString()))
 						return dec.getType().toString();
 				}
 			}
@@ -971,7 +971,7 @@ public class JavaASTParser {
 		for(VariableDeclarationExpression dec:lstVarDecExps){
 			for(Object node:dec.fragments()){
 				if(node instanceof VariableDeclarationFragment){
-					if (((VariableDeclarationFragment)node).getName().toString().equals(name))
+					if (((VariableDeclarationFragment)node).getName().toString().equals(operand.toString()))
 						return dec.getType().toString();
 				}
 			}
@@ -980,7 +980,7 @@ public class JavaASTParser {
 		for(FieldDeclaration dec:lstFieldDecs){
 			for(Object node:dec.fragments()){
 				if(node instanceof VariableDeclarationFragment){
-					if (((VariableDeclarationFragment)node).getName().toString().equals(name))
+					if (((VariableDeclarationFragment)node).getName().toString().equals(operand.toString()))
 						return dec.getType().toString();
 				}
 			}
@@ -988,8 +988,8 @@ public class JavaASTParser {
 		
 		if(astNode.getParent() == null)
 			return "";
-		
-		return getTypeOfSimpleName(astNode.getParent(),name);
+
+		return getTypeOfSimpleName(astNode.getParent(), operand);
 	}
 
 	public ArrayList<SimpleName> getSimpleNames(ASTNode node) {

--- a/src/test/java/ca/uwaterloo/ece/TestSnapshotFeeDetPerProject.java
+++ b/src/test/java/ca/uwaterloo/ece/TestSnapshotFeeDetPerProject.java
@@ -1,0 +1,46 @@
+package ca.uwaterloo.ece;
+
+import ca.uwaterloo.ece.feedet.DetectionRecord;
+import ca.uwaterloo.ece.feedet.bugpatterns.Bug;
+import ca.uwaterloo.ece.feedet.utils.JavaASTParser;
+import org.eclipse.jgit.lib.Repository;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class TestSnapshotFeeDetPerProject {
+    public static List<DetectionRecord> detect(JavaASTParser javaASTParser, String patternName) {
+        List<DetectionRecord> result = new ArrayList<>();
+
+        try {
+            Class<?> bugPatternClass = Class.forName("ca.uwaterloo.ece.feedet.bugpatterns." + patternName);
+            Constructor<?> constructor = bugPatternClass.getConstructor(String.class, JavaASTParser.class, String.class, String.class, Repository.class);
+            result = process(((Bug) constructor.newInstance(null, javaASTParser, null, null, null)).detect());
+
+        } catch (NoSuchMethodException | SecurityException | InstantiationException |
+                 IllegalAccessException | IllegalArgumentException | InvocationTargetException e1) {
+            e1.printStackTrace();
+        } catch (ClassNotFoundException e) {
+            System.err.println("Pattern, " + patternName + ", does not exist. Please check if the pattern name is correct.");
+            System.exit(0);
+        }
+        return result;
+    }
+
+    private static List<DetectionRecord> process(ArrayList<DetectionRecord> detectionRecords) {
+        if (detectionRecords.isEmpty()) {
+            System.out.println("No bugs found");
+        }
+        for (DetectionRecord detRec : detectionRecords) {
+            System.out.println("###\t" + detRec.getPatternName() + "\t"
+                    + detRec.getLineNum() + "\t"
+                    + detRec.getCode()
+            );
+            System.out.println(detRec.getCode());
+            System.out.println(detRec.getSurroundCode());
+        }
+        return detectionRecords;
+    }
+}

--- a/src/test/java/ca/uwaterloo/ece/feefin/IncorrectStringCompareTests.java
+++ b/src/test/java/ca/uwaterloo/ece/feefin/IncorrectStringCompareTests.java
@@ -1,0 +1,66 @@
+package ca.uwaterloo.ece.feefin;
+
+import ca.uwaterloo.ece.TestSnapshotFeeDetPerProject;
+import ca.uwaterloo.ece.feedet.DetectionRecord;
+import ca.uwaterloo.ece.feedet.utils.JavaASTParser;
+import org.junit.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class IncorrectStringCompareTests {
+
+    @Test
+    public void TestBugPatternIncorrectStringCompareTest_75() {
+        // given
+        String src = "public class MyClass {\n" +
+                "    private int s = 1;\n" +
+                "    private int t = 2;\n" +
+                "    \n" +
+                "    public void assignValue(String s) {\n" +
+                "        s = \"str\";\n" +
+                "    }\n" +
+                "    \n" +
+                "    public boolean compareFields() {\n" +
+                "        return s == t;\n" +
+                "    }\n" +
+                "}\n";
+
+        // when
+        JavaASTParser javaASTParser = new JavaASTParser(src);
+        List<DetectionRecord> results =
+                TestSnapshotFeeDetPerProject.detect(javaASTParser, "IncorrectStringCompare");
+
+        // then
+        assertEquals(Collections.emptyList(), results);
+    }
+
+    @Test
+    public void TestBugPatternIncorrectStringCompareTest_102() {
+        // given
+        String src = "public class StringComparator {\n" +
+                "    private String str1;\n" +
+                "    private String str2;\n" +
+                "    \n" +
+                "    public StringComparator(String str1, String str2) {\n" +
+                "        this.str1 = str1;\n" +
+                "        this.str2 = str2;\n" +
+                "    }\n" +
+                "    \n" +
+                "    public boolean compareStrings() {\n" +
+                "        return str1 == str2;\n" +
+                "    }\n" +
+                "}\n";
+
+        // when
+        JavaASTParser javaASTParser = new JavaASTParser(src);
+        List<DetectionRecord> results =
+                TestSnapshotFeeDetPerProject.detect(javaASTParser, "IncorrectStringCompare");
+        DetectionRecord record = results.get(0);
+
+        // then
+        assertEquals("IncorrectStringCompare", record.getPatternName());
+    }
+}


### PR DESCRIPTION
# Summary

Fix a bug inferring non-string type expression as string, causing `IncorrectStringCompare`.

# Description

## Background

This bug was discovered while analysing the open source project [openNLP](https://github.com/apache/opennlp) from Apache.  In the `opennlp-tools` module, one of the bugs was labeled as `IncorrectStringCompare`. 

```shell
% ./FeeDet -d /Users/zionhann/Desktop/dev/opennlp/opennlp-tools
==========
/Users/zionhann/Desktop/dev/opennlp/opennlp-tools
==========
# of all paths: 986
###     IncorrectStringCompare  /Users/zionhann/Desktop/dev/opennlp/opennlp-tools               /Users/zionhann/Desktop/dev/opennlp/opennlp-tools/src/main/java/opennlp/tools/formats/ad/ADSentenceSampleStream.java       155     currentText == text
currentText == text

```

Specifically, `currentText == text` is a comparison between two integer variables, not strings as was initially inferred. The core issue arose from an incorrect type inference for the `text` variable, which was taken out of its scope `private boolean hasPunctuation(String text)`. This inappropriate inference led to the `IncorrectStringCompare`.

```java
public class ADSentenceSampleStream implements ObjectStream<SentenceSample> {

  private int text = -1; // expected
  // ...

  private boolean hasPunctuation(String text) { // actual
      // ...

  }

  private void updateMeta() {
      // ...

      int currentText;
      if (m.matches()) {
        currentText = Integer.parseInt(m.group(1));
        // ...

      }
      // ...

      if (currentText == text)
        isSameText = true;

      // ...

  }
}

```

## Solution

Ensure that the target variable and the method parameter(`SingleVariableDeclaration`) being referenced are within the same scope. This is achieved by adding a verification process for the **method signatures**. During this process, the validation checks not only for identical variable names, but also for matching method declarations. This solution effectively prevents the type variable from being erroneously referenced outside its intended scope.

```java
for (SingleVariableDeclaration dec:lstSingleVarDecs) {
    if (dec.getName().toString().equals(operand.toString())
     && dec.getParent().equals(getMethodDec(operand))) // here
           return dec.getType().toString();
}
```

## Testing

### Configuration

Since the existing code relies heavily on external resources for analysis, it has been challenging to write an independent test case that is unaffected by these resources. Therefore, I suggest creating a specific configuration file for testing, [`TestSnapshotFeeDetPerProject.java`](https://github.com/HGUISEL/FeeFin/pull/1/files#diff-d483d3434932efb7de28444cdee833b62ece26a99f105f77d3b366c75208ca6c). This file is a duplicate of `SnapshotFeeDetPerProject`, but the critical difference is that it discards any dependencies, allowing it to exclusively handle Java source code without the need for specific file paths.

For instance, to test specific code, you can simply write:

```java
String src = "public class MyClass { ... }";

JavaASTParser javaASTParser = new JavaASTParser(src);
List<DetectionRecord> results =
        TestSnapshotFeeDetPerProject.detect(javaASTParser, "IncorrectStringCompare");
```

### Result

Given the code snippet below, the current `FeeFin` incorrectly throws `IncorrectStringCompare`, identifying the expression **`s == t`** as a bug. Note that this is a false positive since the variables `s` and `t` are of type `int`.

```java
public class MyClass {
    private int s = 1;
    private int t = 2;
    
    public void assignValue(String s) {
        s = "str";
    }
    
    public boolean compareFields() {
        return s == t;
    }
}
```

```bash
###	IncorrectStringCompare	10	s == t
s == t

Expected :[]
Actual   :[ca.uwaterloo.ece.feedet.DetectionRecord@e46fb29e]
```

With the proposed changes implemented, we can verify that the given code doesn't contain the `IncorrectStringCompare` pattern.

<img width="240" alt="Screenshot 2023-05-29 at 16 57 59" src="https://github.com/HGUISEL/FeeFin/assets/45687157/534d0418-ac92-4930-8078-d05ee3adf3c6">
